### PR TITLE
fix: 修复无法搜索大写字母的问题

### DIFF
--- a/packages/www/src/App.vue
+++ b/packages/www/src/App.vue
@@ -185,7 +185,7 @@ export default {
 
         search() {
             if ('' !== this.keyword) {
-                this.rules = this.rules.filter(({ title }) => -1 !== title.indexOf(this.keyword.toLowerCase()));
+                this.rules = this.rules.filter(({ title }) => -1 !== title.toLowerCase().indexOf(this.keyword.toLowerCase()));
             } else {
                 this.rules = RULES;
             }


### PR DESCRIPTION
如果标题是大写，WEB 搜索中得不到期望的结果。

例如这个 PR [#153](https://github.com/any86/any-rule/pull/153)，搜索 UUID 结果为空。当前线上版本已有的 IMEI 也无法搜索到：

![image](https://user-images.githubusercontent.com/25103518/110232845-3d2c5880-7f5b-11eb-950d-810219c30398.png)

![image](https://user-images.githubusercontent.com/25103518/110232953-fbe87880-7f5b-11eb-93d4-1ef0c152a920.png)

